### PR TITLE
Do not log on download path mismatch

### DIFF
--- a/Classes/Middleware/TrackDownload.php
+++ b/Classes/Middleware/TrackDownload.php
@@ -32,8 +32,14 @@ final class TrackDownload implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        $downloadPath = $request->getUri()->getPath();
+
+        if (!$this->downloadPathMapper->acceptsDownloadPath($downloadPath)) {
+            return $handler->handle($request);
+        }
+
         try {
-            $filePath = $this->downloadPathMapper->toFilePath($request->getUri()->getPath());
+            $filePath = $this->downloadPathMapper->toFilePath($downloadPath);
         } catch (InvalidDownloadPathException $e) {
             $this->logger->warning($e->getMessage(), [
                 'exception' => $e,
@@ -42,8 +48,7 @@ final class TrackDownload implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $site = $request->getAttribute('site');
-        $fileUri = (string)$site->getBase()->withPath($filePath);
+        $fileUri = (string)$request->getAttribute('site')->getBase()->withPath($filePath);
         $request = $request->withAttribute('matomo.attributes', [
             new Download($fileUri),
         ]);

--- a/Classes/Tracking/Download/DownloadPathMapper.php
+++ b/Classes/Tracking/Download/DownloadPathMapper.php
@@ -24,15 +24,16 @@ final class DownloadPathMapper
         return sprintf('%s%s', self::PATH_PREFIX, $filePathWithHmac);
     }
 
+    public function acceptsDownloadPath(string $downloadPath): bool
+    {
+        return str_starts_with($downloadPath, self::PATH_PREFIX);
+    }
+
     /**
      * @throws InvalidDownloadPathException
      */
     public function toFilePath(string $downloadPath): string
     {
-        if (!str_starts_with($downloadPath, self::PATH_PREFIX)) {
-            throw new InvalidDownloadPathException(sprintf('Missing prefix in download path "%s"', $downloadPath), 1744785285);
-        }
-
         $filePathWithHmac = substr($downloadPath, self::PATH_PREFIX_LENGTH);
 
         try {


### PR DESCRIPTION
If download tracking is enabled, the TrackDownload middleware is invoked for every single page URI. This means that there is a mismatch in the most cases which led to a warning written to the TYPO3 log file. This could cause that log file to grow in size quickly.

Avoid this by doing a simpler check for the incoming request path to skip the log message.