### PR TITLE
Do not track redirects as page views

### DIFF
--- a/Classes/Middleware/TrackPageView.php
+++ b/Classes/Middleware/TrackPageView.php
@@ -25,6 +25,11 @@ final class TrackPageView implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
+
+        if ($response->getStatusCode() >= 300 && $response->getStatusCode() <= 399) {
+            return $response;
+        }
+
         $pageTitle = $this->pageTitleResolver->resolvePageTitle($request, $response);
 
         try {


### PR DESCRIPTION
Tracking these has no value since the redirect source is never viewed by humans.