### PR TITLE
Skip download tracking without site

### DIFF
--- a/Classes/Tracking/Typo3ActionFactory.php
+++ b/Classes/Tracking/Typo3ActionFactory.php
@@ -10,6 +10,7 @@ use Pagemachine\MatomoTracking\Tracking\Attributes\Url;
 use Pagemachine\MatomoTracking\Tracking\Attributes\VisitorIpAddress;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
 
 /**
  * Create various attributes from TYPO3-specific info
@@ -38,10 +39,14 @@ final class Typo3ActionFactory implements ActionFactoryInterface
         $action = $this->decorated->createActionFromRequest($serverRequest)
             ->withAttribute(new Url((string)$this->getRequestUri($serverRequest)));
 
-        $siteId = $serverRequest->getAttribute('site')?->getConfiguration()['matomoTrackingSiteId'] ?? null;
+        $site = $serverRequest->getAttribute('site');
 
-        if (!empty($siteId)) {
-            $action = $action->withAttribute(new SiteId($siteId));
+        if ($site instanceof Site) {
+            $siteId = $site->getConfiguration()['matomoTrackingSiteId'] ?? null;
+
+            if (!empty($siteId)) {
+                $action = $action->withAttribute(new SiteId($siteId));
+            }
         }
 
         if (!empty($this->authToken)) {

--- a/Tests/Functional/TrackDownloadTest.php
+++ b/Tests/Functional/TrackDownloadTest.php
@@ -195,6 +195,21 @@ final class TrackDownloadTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function redirectToFileWithoutSite(): void
+    {
+        $response = $this->executeFrontendSubRequest((new InternalRequest('http://localhost/'))->withPageId(1));
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $fileLink = $this->getLinksFromResponse($response)->item(0);
+
+        $response = $this->executeFrontendSubRequest(new InternalRequest('http://unknown.localhost' . $fileLink->getAttribute('href')));
+
+        self::assertSame(307, $response->getStatusCode());
+        self::assertSame('/fileadmin/smallest-possible-pdf-1.0.pdf', $response->getHeaderLine('location'));
+    }
+
+    #[Test]
     public function trackDownloadWithDoNotTrackDisabled(): void
     {
         $response = $this->executeFrontendSubRequest(


### PR DESCRIPTION
If a valid download path is requested without a matching site, the TYPO3 SiteResolver middleware resolves to a NullSite. In this case we cannot have any Matomo tracking configuration. We now catch this case and skip the download tracking. We still redirect to the file since the file would have been accessible anyways if download tracking was not enabled.