### PR TITLE
Drop Composer "prefer lowest" build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: 'PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }}, Composer lowest: ${{ matrix.composer_lowest }}'
+    name: 'PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }}'
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,9 +24,6 @@ jobs:
           - '8.3'
         typo3:
           - ^13.4
-        composer_lowest:
-          - '0'
-          - '1'
 
     steps:
       - uses: actions/checkout@v6
@@ -35,7 +32,6 @@ jobs:
         env:
           PHP_VERSION: ${{matrix.php}}
           TYPO3_VERSION: ${{matrix.typo3}}
-          COMPOSER_PREFER_LOWEST: ${{matrix.composer_lowest}}
         run: docker compose run --rm app composer build
 
       - name: Cleanup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       db:
         condition: service_healthy
     environment:
-      COMPOSER_PREFER_LOWEST:
       PHP_EXTENSIONS: gd intl
       PHP_INI_DATE__TIMEZONE: Europe/Berlin
       PHP_INI_MAX_EXECUTION_TIME: 240


### PR DESCRIPTION
Unfortunately this also affects "require-dev" which requires us to basically check each and every direct or transitive dependency for full compatibility. This is not feasible right now so this build is dropped.

Since this project is not a library possible issues should be acceptable since they can be fixed on demand.